### PR TITLE
Use Shopware Kernel Cache directory

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -3,6 +3,11 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="shyim_profiler.cache_dir">%kernel.cache_dir%/ShyimProfiler</parameter>
+    </parameters>
+
     <services>
         <!-- Custom Services -->
         <service id="shyim_profiler.smarty_extensions" class="ShyimProfiler\Components\SmartyExtensions"/>

--- a/ShyimProfiler.php
+++ b/ShyimProfiler.php
@@ -22,9 +22,9 @@ class ShyimProfiler extends Plugin
     public function build(ContainerBuilder $container)
     {
         $container->setParameter('shyim_profiler.plugin_dir', $this->getPath() . '/');
-        $container->setParameter('shyim_profiler.cache_dir', $this->getPath() . '/ProfilerCache');
+
         parent::build($container);
-        
+
         $container->addCompilerPass(new EventListenerCompilerPass());
         $container->addCompilerPass(new EventSubscriberCompilerPass());
     }


### PR DESCRIPTION
Plugins should not create files in their plugin directory. For cache files the existing cache directory should be used.