### PR TITLE
Add buildscript to build installable zip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+lastTag=$(git tag | tail -n 1)
+customTag=$1
+
+if [ "$customTag" != "" ]; then lastTag=$customTag; fi
+if [ "$lastTag" = "" ]; then lastTag="master"; fi
+
+rm -f ShyimProfiler-${lastTag}.zip
+rm -rf ShyimProfiler
+mkdir -p ShyimProfiler
+git archive $lastTag | tar -x -C ShyimProfiler
+
+cd ShyimProfiler
+composer install --no-dev -n -o
+cd ../
+zip -r ShyimProfiler-${lastTag}.zip ShyimProfiler


### PR DESCRIPTION
This commit adds an bash script to build an ZIP file that can be used for the Shopware Plugin Manager.

You should consider tagging your current release, build a zip file and add it to the github release page. 
See: https://github.com/shopwareLabs/SwagMediaS3/releases