### PR TITLE
pass all arguments

### DIFF
--- a/Resources/views/@Profiler/index.tpl
+++ b/Resources/views/@Profiler/index.tpl
@@ -12,7 +12,7 @@
     var ajaxBeforeSend = window.CSRF._ajaxBeforeSend;
 
     window.CSRF._ajaxBeforeSend = function (event, request) {
-        ajaxBeforeSend.apply(window.CSRF, [event, request]);
+        ajaxBeforeSend.apply(window.CSRF, arguments);
         request.setRequestHeader('X-Profiler', '{$sProfilerID}');
     };
 </script>


### PR DESCRIPTION
By using the arguments object, all arguments will be passed to the original ajaxBeforeSend method to ensure compatibility.