### PR TITLE
Revert updating composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,6 @@
   "extra": {
     "installer-name": "ShyimProfiler"
   },
-  "replace": {
-    "symfony/polyfill-mbstring": "~1.0"
-  },
   "require": {
     "php" : "^7.0",
     "symfony/var-dumper": "^3.2",


### PR DESCRIPTION
This just reverts commit 44d95e9df244f374656242c729b60bf7b03d94cb. The proper fix may be to just fix the `"jdorn/sql-formatter": "^v1.2.17"` require statement.

This is currently causing any satis build that includes `provider-symfony/polyfill-mbstring.json` to fail with the following exception:

```
[RuntimeException]                                                                                                                                                                  
  Could not load package shyim/shopware-profiler in https://packagist.org: [UnexpectedValueException] Could not parse version constraint ^v1.2.17: Invalid version string "^v1.2.17"
```