### PR TITLE
increase with of column for template files list

### DIFF
--- a/Resources/views/frontend/profiler/tabs/template.tpl
+++ b/Resources/views/frontend/profiler/tabs/template.tpl
@@ -19,7 +19,7 @@
 <table class="">
     <thead>
         <tr>
-            <th scope="col" class="key">Template Name</th>
+            <th scope="col">Template Name</th>
             <th scope="col">Render Count</th>
         </tr>
     </thead>


### PR DESCRIPTION
On the template tab the first column includes most of the content (names of included template files) and therefore it should own all of the available space of the table instead of the render count column ;-)